### PR TITLE
Move to VagrantPlugins top-level namespace

### DIFF
--- a/lib/vagrant-cachier/action.rb
+++ b/lib/vagrant-cachier/action.rb
@@ -1,6 +1,6 @@
 require_relative 'bucket'
 
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Action
       class Install

--- a/lib/vagrant-cachier/bucket.rb
+++ b/lib/vagrant-cachier/bucket.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Bucket
       def self.inherited(base)

--- a/lib/vagrant-cachier/bucket/apt.rb
+++ b/lib/vagrant-cachier/bucket/apt.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Bucket
       class Apt < Bucket

--- a/lib/vagrant-cachier/bucket/gem.rb
+++ b/lib/vagrant-cachier/bucket/gem.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Bucket
       class Gem < Bucket

--- a/lib/vagrant-cachier/bucket/pacman.rb
+++ b/lib/vagrant-cachier/bucket/pacman.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Bucket
       class Pacman < Bucket

--- a/lib/vagrant-cachier/bucket/yum.rb
+++ b/lib/vagrant-cachier/bucket/yum.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Bucket
       class Yum < Bucket

--- a/lib/vagrant-cachier/cap/arch/pacman_cache_dir.rb
+++ b/lib/vagrant-cachier/cap/arch/pacman_cache_dir.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     module Cap
       module Arch

--- a/lib/vagrant-cachier/cap/debian/apt_cache_dir.rb
+++ b/lib/vagrant-cachier/cap/debian/apt_cache_dir.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     module Cap
       module Debian

--- a/lib/vagrant-cachier/cap/linux/gemdir.rb
+++ b/lib/vagrant-cachier/cap/linux/gemdir.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     module Cap
       module Linux

--- a/lib/vagrant-cachier/cap/redhat/yum_cache_dir.rb
+++ b/lib/vagrant-cachier/cap/redhat/yum_cache_dir.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     module Cap
       module RedHat

--- a/lib/vagrant-cachier/config.rb
+++ b/lib/vagrant-cachier/config.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Config < Vagrant.plugin(2, :config)
       attr_accessor :scope, :auto_detect

--- a/lib/vagrant-cachier/plugin.rb
+++ b/lib/vagrant-cachier/plugin.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     class Plugin < Vagrant.plugin('2')
       name 'vagrant-cachier'
@@ -30,14 +30,14 @@ module Vagrant
 
       install_action_hook = lambda do |hook|
         require_relative 'action'
-        hook.after Vagrant::Action::Builtin::Provision, Vagrant::Cachier::Action::Install
+        hook.after Vagrant::Action::Builtin::Provision, VagrantPlugins::Cachier::Action::Install
       end
       action_hook 'set-shared-cache-on-machine-up',     :machine_action_up, &install_action_hook
       action_hook 'set-shared-cache-on-machine-reload', :machine_action_reload, &install_action_hook
 
       clean_action_hook = lambda do |hook|
         require_relative 'action'
-        hook.before Vagrant::Action::Builtin::GracefulHalt, Vagrant::Cachier::Action::Clean
+        hook.before Vagrant::Action::Builtin::GracefulHalt, VagrantPlugins::Cachier::Action::Clean
       end
       action_hook 'remove-guest-symlinks-on-machine-halt',    :machine_action_halt, &clean_action_hook
       action_hook 'remove-guest-symlinks-on-machine-package', :machine_action_package, &clean_action_hook

--- a/lib/vagrant-cachier/version.rb
+++ b/lib/vagrant-cachier/version.rb
@@ -1,4 +1,4 @@
-module Vagrant
+module VagrantPlugins
   module Cachier
     VERSION = "0.0.6"
   end


### PR DESCRIPTION
Heyo. Was just trying to write a helper function to see when a plugin was installed, and was having issues with vagrant-cachier. Finally realized it was because you're using `module Vagrant` rather than the recommended top-level namespace -- `VagrantPlugins`:

See https://github.com/mitchellh/vagrant-rackspace/blob/master/lib/vagrant-rackspace/action.rb#L5

I don't suppose you'd be willing to change this? PR pending
