### PR TITLE
New gem release: 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,12 @@
-# 0.0.2 Initial release
+## 0.1.1 (unreleased)
+
+## 0.1.0 (June 9, 2013)
+
+IMPROVEMENTS:
+
+  - Moves from `Vagrant` to recommended `VagrantPlugins` top-level
+    module namespace. [GH-9]
+
+## 0.0.6 (May 22, 2013)
+
+  - Initial public release.

--- a/lib/vagrant-cachier/version.rb
+++ b/lib/vagrant-cachier/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Cachier
-    VERSION = "0.0.6"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
Or does this count as a major version bump according to [semver](http://semver.org/)? But I suppose `0.y.z` is technically for pre-release :)

https://github.com/fgrehm/vagrant-cachier/compare/v0.0.6...master

PR forthcoming. :+1: to confirm my rolling of a new release.
