### PR TITLE
Don't error out if a bucket is configured for a non-capable guest

### DIFF
--- a/lib/vagrant-cachier/bucket/apt.rb
+++ b/lib/vagrant-cachier/bucket/apt.rb
@@ -24,8 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured an APT cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping APT cache bucket as the guest machine does not support it"
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/chef.rb
+++ b/lib/vagrant-cachier/bucket/chef.rb
@@ -24,8 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured a Chef cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping Chef cache bucket as the guest machine does not support it"
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/gem.rb
+++ b/lib/vagrant-cachier/bucket/gem.rb
@@ -29,8 +29,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured a RubyGems cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping RubyGems cache bucket as the guest machine does not support it"
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/pacman.rb
+++ b/lib/vagrant-cachier/bucket/pacman.rb
@@ -24,8 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured a Pacman cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping Pacman cache bucket as the guest machine does not support it"
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/rvm.rb
+++ b/lib/vagrant-cachier/bucket/rvm.rb
@@ -29,8 +29,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured a RVM cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping RVM cache bucket as the guest machine does not support it"
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/yum.rb
+++ b/lib/vagrant-cachier/bucket/yum.rb
@@ -27,8 +27,7 @@ module VagrantPlugins
               end
             end
           else
-            # TODO: Raise a better error
-            raise "You've configured a Yum cache for a guest machine that does not support it!"
+            @env[:ui].info "Skipping Yum cache bucket as the guest machine does not support it"
           end
         end
       end


### PR DESCRIPTION
Currently if you explicitly enable a bucket and the guest does not support it, a `RuntimeError` is raised. I would like to globally have `auto_detect` turned off (as I use a caching proxy for apt), but enable yum and gem caches. But then the yum bucket gets angry on debianoid boxes. :/

IMHO a warning message would be enough in these cases. I can make a PR if you agree.

If the consensus is against it, at least the raised error should at least be a subclass of `Vagrant::Errors::VagrantError` (see "ERROR HANDLING" in the [docs](http://docs.vagrantup.com/v2/plugins/development-basics.html)). And I would like to have something like this instead:

``` ruby
config.cache.enable :yum, auto_detect: true
```
