### PR TITLE
Use precise64 as box for all fixtures

### DIFF
--- a/spec/acceptance/fixtures/auto-detect-with-provisioning.rb
+++ b/spec/acceptance/fixtures/auto-detect-with-provisioning.rb
@@ -5,5 +5,6 @@ Vagrant.configure("2") do |config|
   config.cache.scope = :machine
 
   config.vm.box = 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
   config.vm.provision :shell, inline: 'apt-get update && apt-get install -y git'
 end

--- a/spec/acceptance/fixtures/auto-detect.rb
+++ b/spec/acceptance/fixtures/auto-detect.rb
@@ -3,5 +3,6 @@ Vagrant.require_plugin 'vagrant-lxc'
 Vagrant.configure("2") do |config|
   config.cache.auto_detect = true
   config.vm.box = 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
   config.vm.provision :shell, inline: 'echo Hello!'
 end

--- a/spec/acceptance/fixtures/no-cachier-simple.rb
+++ b/spec/acceptance/fixtures/no-cachier-simple.rb
@@ -2,4 +2,5 @@ Vagrant.require_plugin 'vagrant-cachier'
 Vagrant.require_plugin 'vagrant-lxc'
 Vagrant.configure("2") do |config|
   config.vm.box = 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
 end

--- a/spec/acceptance/fixtures/no-cachier-with-provisioning.rb
+++ b/spec/acceptance/fixtures/no-cachier-with-provisioning.rb
@@ -2,5 +2,6 @@ Vagrant.require_plugin 'vagrant-cachier'
 Vagrant.require_plugin 'vagrant-lxc'
 Vagrant.configure("2") do |config|
   config.vm.box = 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
   config.vm.provision :shell, inline: 'echo Hello!'
 end


### PR DESCRIPTION
This PR sets all fixtures to use `precise64`, so that new developers
would not have to download more boxes to run the specs than they need
to.  We also set a URL for `precise64`, so Vagrant can download the box
if it hasn't yet.

I settled with `precise64` as it is the current LTS, and because there
is a box for it at `http://files.vagrantup.com`.
