### PR TITLE
Fix NFS configs for 1.4

### DIFF
--- a/lib/vagrant-cachier/provision_ext.rb
+++ b/lib/vagrant-cachier/provision_ext.rb
@@ -17,8 +17,12 @@ module VagrantPlugins
 
             FileUtils.mkdir_p(cache_root.to_s) unless cache_root.exist?
 
-            nfs_flag = env[:machine].config.cache.enable_nfs
-            env[:machine].config.vm.synced_folder cache_root, '/tmp/vagrant-cache', id: "vagrant-cache", nfs: nfs_flag
+            synced_folder_opts = {id: "vagrant-cache"}
+            if env[:machine].config.cache.enable_nfs
+              # REFACTOR: Drop the `nfs: true` argument once we drop support for Vagrant < 1.4
+              synced_folder_opts.merge!({ nfs: true, type: 'nfs' })
+            end
+            env[:machine].config.vm.synced_folder cache_root, '/tmp/vagrant-cache', synced_folder_opts
 
             env[:cache_dirs] = []
 


### PR DESCRIPTION
This is the fix for GH-67 but as there are some open issues related to NFS with VirtualBox on Vagrant's core I can't really be sure that things are working fine (I think the one that consolidates them is https://github.com/mitchellh/vagrant/issues/2674). But since I was able to reproduce the original bug, this should be enough to fix things from our side and will allow people to use Vagrant < 1.4 as well.

@tuminoid would you mind [installing the plugin from sources](http://fgrehm.viewdocs.io/vagrant-cachier/development) out of this branch and double checking that it works fine on vmware? If you need any help with that please LMK.

/cc @phinze
