### PR TITLE
README.md - conditional plugin specific configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ from within your `Vagrantfile`:
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.box = 'your-box'
-  config.cache.auto_detect = true
-  # If you are using VirtualBox, you might want to enable NFS for shared folders
-  # config.cache.enable_nfs  = true
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.auto_detect = true
+    # If you are using VirtualBox, you might want to enable NFS for shared folders
+    # config.cache.enable_nfs  = true
+  end
 end
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,11 @@ from within your `Vagrantfile`:
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.box = 'your-box'
-  config.cache.auto_detect = true
-  # If you are using VirtualBox, you might want to enable NFS for shared folders
-  # config.cache.enable_nfs  = true
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.auto_detect = true
+    # If you are using VirtualBox, you might want to enable NFS for shared folders
+    # config.cache.enable_nfs  = true
+  end
 end
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,12 +3,17 @@
 ## Auto detect supported cache buckets
 
 This is the easiest way to get started with plugin. By adding the code below to
-your `Vagrantfile` you can enable automatic detection of supported cache _buckets_:
+your `Vagrantfile` you can enable automatic detection of supported cache _buckets_.
+It is a good practise to wrap plugin specific configuration with `has_plugin?` checks
+so the user's Vagrantfiles do not break if plugin is uninstalled or Vagrantfile shared
+with people not having the plugin installed.
 
 ```ruby
 Vagrant.configure("2") do |config|
   # ...
-  config.cache.auto_detect = true
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.auto_detect = true
+  end
 end
 ```
 


### PR DESCRIPTION
Wrap plugin specific configs into has_plugin checks to avoid breakage when Vagrantfile is shared and/or plugin is removed (for testing/development).
