### PR TITLE
Use our own Vagrant::UI for logging

### DIFF
--- a/lib/vagrant-cachier/action/clean.rb
+++ b/lib/vagrant-cachier/action/clean.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
           @machine = env[:machine]
 
           if symlinks.any?
-            env[:ui].info I18n.t('vagrant_cachier.cleanup')
+            Cachier.ui.info I18n.t('vagrant_cachier.cleanup')
             if sshable?
               symlinks.each do |symlink|
                 remove_symlink symlink
@@ -43,7 +43,7 @@ module VagrantPlugins
               end
             end
           rescue Timeout::Error
-            @env[:ui].warn(I18n.t('vagrant_cachier.unable_to_ssh'))
+            Cachier.ui.warn(I18n.t('vagrant_cachier.unable_to_ssh'))
           end
 
           return false

--- a/lib/vagrant-cachier/action/ensure_single_cache_root.rb
+++ b/lib/vagrant-cachier/action/ensure_single_cache_root.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
             new_path = new_path.to_s.gsub(/^#{@env[:root_path]}\//, '')
             # If we got here there is a single provider specific cacher dir, so
             # let's be nice with users and just fix it ;)
-            @env[:ui].warn I18n.t('vagrant_cachier.will_fix_machine_cache_dir',
+            Cachier.ui.warn I18n.t('vagrant_cachier.will_fix_machine_cache_dir',
                                   current_path: current_path,
                                   new_path:     new_path)
             FileUtils.mv current_path, new_path

--- a/lib/vagrant-cachier/bucket/apt.rb
+++ b/lib/vagrant-cachier/bucket/apt.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'APT')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'APT')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/apt_cacher.rb
+++ b/lib/vagrant-cachier/bucket/apt_cacher.rb
@@ -26,11 +26,11 @@ module VagrantPlugins
                   end
                 end
               else
-                @env[:ui].info I18n.t('vagrant_cachier.nfs_required', bucket: 'apt-cacher')
+                Cachier.ui.info I18n.t('vagrant_cachier.nfs_required', bucket: 'apt-cacher')
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'apt-cacher')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'apt-cacher')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/chef.rb
+++ b/lib/vagrant-cachier/bucket/chef.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Chef')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Chef')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/composer.rb
+++ b/lib/vagrant-cachier/bucket/composer.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Composer')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Composer')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/gem.rb
+++ b/lib/vagrant-cachier/bucket/gem.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'RubyGems')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'RubyGems')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/npm.rb
+++ b/lib/vagrant-cachier/bucket/npm.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'npm')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'npm')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/pacman.rb
+++ b/lib/vagrant-cachier/bucket/pacman.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Pacman')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Pacman')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/rvm.rb
+++ b/lib/vagrant-cachier/bucket/rvm.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'RVM')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'RVM')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/yum.rb
+++ b/lib/vagrant-cachier/bucket/yum.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Yum')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Yum')
           end
         end
       end

--- a/lib/vagrant-cachier/bucket/zypper.rb
+++ b/lib/vagrant-cachier/bucket/zypper.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
               end
             end
           else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Zypper')
+            Cachier.ui.info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Zypper')
           end
         end
       end

--- a/lib/vagrant-cachier/plugin.rb
+++ b/lib/vagrant-cachier/plugin.rb
@@ -8,6 +8,10 @@ I18n.load_path << File.expand_path("../../../locales/en.yml", __FILE__)
 
 module VagrantPlugins
   module Cachier
+    def self.ui
+      @ui ||= ::Vagrant::UI::Colored.new.scope('Cachier')
+    end
+
     class Plugin < Vagrant.plugin('2')
       name 'vagrant-cachier'
 

--- a/lib/vagrant-cachier/provision_ext.rb
+++ b/lib/vagrant-cachier/provision_ext.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
 
             return unless @env[:machine].config.cache.buckets.any?
 
-            @env[:ui].info 'Configuring cache buckets...'
+            Cachier.ui.info 'Configuring cache buckets...'
             cache_config = @env[:machine].config.cache
             cache_config.buckets.each do |bucket_name, configs|
               cachier_debug "Installing #{bucket_name} with configs #{configs.inspect}"


### PR DESCRIPTION
This causes log output to look like:

```
[Cachier] Configuring cache buckets...
```

instead of:

```
[default] Configuring cache buckets...
```

Memoizing a class instance variable in Cacher.ui is probably not the best way to accomplish this. Suggestions welcome.
