### PR TITLE
Allow vagrant-cachier to support offline provisioning of apt packages

### DIFF
--- a/lib/vagrant-cachier/bucket/apt.rb
+++ b/lib/vagrant-cachier/bucket/apt.rb
@@ -11,22 +11,27 @@ module VagrantPlugins
           guest   = machine.guest
 
           if guest.capability?(:apt_cache_dir)
-            guest_path = guest.capability(:apt_cache_dir)
-
-            @env[:cache_dirs] << guest_path
-
+            apt_capability = guest.capability(:apt_cache_dir) 
             machine.communicate.tap do |comm|
-              comm.execute("mkdir -p /tmp/vagrant-cache/#{@name}/partial")
-              unless comm.test("test -L #{guest_path}")
-                comm.sudo("rm -rf #{guest_path}")
-                comm.sudo("mkdir -p `dirname #{guest_path}`")
-                comm.sudo("ln -s /tmp/vagrant-cache/#{@name} #{guest_path}")
-              end
+              create_apt_symlink(comm, apt_capability[:archives_dir])
+              create_apt_symlink(comm, apt_capability[:lists_dir])
             end
           else
             @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'APT')
           end
         end
+
+        private
+        def create_apt_symlink(comm, path)
+          @env[:cache_dirs] << path
+          folder = File.basename(path)	
+          comm.execute("mkdir -p /tmp/vagrant-cache/#{@name}/#{folder}/partial")
+          unless comm.test("test -L #{path}")
+            comm.sudo("rm -rf #{path}")
+            comm.sudo("mkdir -p `dirname #{path}`")
+            comm.sudo("ln -s /tmp/vagrant-cache/#{@name}/#{folder} #{path}")
+          end
+        end	
       end
     end
   end

--- a/lib/vagrant-cachier/cap/debian/apt_cache_dir.rb
+++ b/lib/vagrant-cachier/cap/debian/apt_cache_dir.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         module AptCacheDir
           def self.apt_cache_dir(machine)
             # TODO: Find out if there is a config file we can read from
-            '/var/cache/apt/archives'
+			{ :archives_dir => '/var/cache/apt/archives', :lists_dir => '/var/lib/apt/lists'}
           end
         end
       end

--- a/spec/acceptance/sanity_check.bats
+++ b/spec/acceptance/sanity_check.bats
@@ -24,21 +24,29 @@ load test_helper
 @test "APT cache bucket configures the cache dir properly and keeps cache dir around" {
   configure_env "auto-detect-with-provisioning.rb"
 
-  # Make sure cache dir does not exist
-  test ! -d tmp/.vagrant/machines/default/cache/apt
+  # Make sure cache/lista dir does not exist
+  test ! -d tmp/.vagrant/machines/default/cache/apt/archives
+  test ! -d tmp/.vagrant/machines/default/cache/apt/lists
 
   vagrant_up
   [ "$status" -eq 0 ]
 
   # Make sure packages are being cached
-  test -d tmp/.vagrant/machines/default/cache/apt
-  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/git*.deb`)
+  test -d tmp/.vagrant/machines/default/cache/apt/archives
+  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/archives/git*.deb`)
+  [ ${#FILES[@]} -gt 0 ]
+  
+  test -d tmp/.vagrant/machines/default/cache/apt/lists
+  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/lists/*Packages`)
   [ ${#FILES[@]} -gt 0 ]
 
   vagrant_destroy
 
   # Make sure packages are not removed between machine rebuilds
-  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/git*.deb`)
+  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/archives/git*.deb`)
+  [ ${#FILES[@]} -gt 0 ]
+  
+  FILES=(`ls tmp/.vagrant/machines/default/cache/apt/lists/*Packages`)
   [ ${#FILES[@]} -gt 0 ]
 
   empty_cache


### PR DESCRIPTION
Hi,

I have made some small changes to allow vagrant-cachier to support provisioning a debian box while offline. This is particularly useful when developing on the train etc. Hopefully you will find this pull request useful.

According to [Wikipedia](http://en.wikipedia.org/wiki/Advanced_Packaging_Tool#Files) /var/lib/apt/lists is the "storage area for state information for each package resource specified in sources.list". I have added this directory to the cached directories in the apt bucket. This enables apt to install cached packages without hitting the remote repositories for the main package lists.
