### PR TITLE
fix compatibility with ruby 1.9.3

### DIFF
--- a/lib/vagrant-cachier/bucket.rb
+++ b/lib/vagrant-cachier/bucket.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
       end
 
       # TODO: "merge" symlink and user_symlink methods
-      def symlink(guest_path, bucket_path = "/tmp/vagrant-cache/#{@name}", create_parent: true)
+      def symlink(guest_path, bucket_path = "/tmp/vagrant-cache/#{@name}", create_parent = true)
         return if @env[:cache_dirs].include?(guest_path)
 
         @env[:cache_dirs] << guest_path


### PR DESCRIPTION
When using vagrant-cachier in a Ruby 1.9.3 environment I get his error:

```
D:\Repos\_github\vagrant-managed-servers>bundle exec vagrant destroy -f fake_managed_server
W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/action/install_buckets.rb:1:in `require_relative': W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/bucket.rb:46: syntax error, unexpected tLABEL (SyntaxError)
...cache/#{@name}", create_parent: true)
...                               ^
W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/bucket.rb:88: syntax error, unexpected keyword_end, expecting $end
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/action/install_buckets.rb:1:in `<top (required)>'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/hooks.rb:6:in `require_relative'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/vagrant-cachier-0.6.0/lib/vagrant-cachier/hooks.rb:6:in `block in <class:Plugin>'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:45:in `call'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:45:in `block (2 levels) in run'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:44:in `tap'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:44:in `block in run'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:43:in `map'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/action/runner.rb:43:in `run'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/environment.rb:283:in `hook'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/lib/vagrant/environment.rb:139:in `initialize'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/bin/vagrant:105:in `new'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bundler/gems/vagrant-4f0eb9504cc7/bin/vagrant:105:in `<top (required)>'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bin/vagrant:23:in `load'
        from W:/tools/ruby-1.9.3/lib/ruby/gems/1.9.1/bin/vagrant:23:in `<main>'
```

I believe the `create_parent: true` syntax works for Ruby 2.0.0 but not for 1.9.3. Switching to `create_parent = true` fixes the problem.

P.S.: I'm getting this while developing a vagrant plugin with my 1.9.3 system ruby.
