### PR TITLE
Cache omnibus download (via "pseudo bucket")

### DIFF
--- a/lib/vagrant-cachier/action/configure_bucket_root.rb
+++ b/lib/vagrant-cachier/action/configure_bucket_root.rb
@@ -35,6 +35,8 @@ module VagrantPlugins
           # unfortunately vagrant-omnibus hooks in before our buckets are installed, yet
           # this is early enough to tell it to download to the vagrant-omnibus pseudo bucket
           if @env[:machine].config.cache.auto_detect && omnibus_plugin_detected? && omnibus_plugin_enabled?
+            omnibus_pseudo_bucket = host_cache_root.join('vagrant_omnibus')
+            FileUtils.mkdir(omnibus_pseudo_bucket.to_s) unless omnibus_pseudo_bucket.exist?
             ENV['OMNIBUS_DOWNLOAD_DIR'] ||= "#{guest_cache_root}/vagrant_omnibus"
           end
         end


### PR DESCRIPTION
This creates a `vagrant_omnibus` "pseudo bucket" for caching the omnibus packages downloaded via vagrant-omnibus.

It caches the omnibus packages only iff:
1. bucket auto detection is enabled
2. vagrant-omnibus plugin is detected
3. vagrant-omnibus is enabled for that VM

The reason I call this "pseudo bucket" is that it's not implemented as a real bucket + capability. I actually [tried this approach first](https://github.com/tknerr/vagrant-cachier/compare/master...cache-omnibus-download-this-doesnt-work) but it didn't work as vagrant-cachier installs the buckets too late (i.e. _after_ vagrant-omnibus runs the install.sh). So I ended up creating a `vagrant_omnibus` pseudo bucket in `ConfigureBucketRoot#call()` which is early enough.

If you have better ideas let me know, this was the best I could get at...

See [discussion in #13](https://github.com/fgrehm/vagrant-cachier/issues/13#issuecomment-37099784) as well.
