### PR TITLE
Fix multi generic bucket set up

### DIFF
--- a/docs/buckets/generic.md
+++ b/docs/buckets/generic.md
@@ -10,20 +10,22 @@ end
 ```
 
 The `:cache_dir` parameter is required. It specifies the directory on the guest
-that will be cached under the "generic" bucket.
+that will be cached under the "/tmp/vagrant-cache/generic" bucket.
 
-You may enable more than one generic bucket by giving them different names via
-the `:name` parameter, like this:
+You may enable more than one generic bucket by giving them different names,
+like this:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.cache.enable :generic, { name: "one", cache_dir: "/var/cache/one" }
-  config.cache.enable :generic, { name: "two", cache_dir: "/var/cache/two" }
+  config.cache.enable :generic, {
+    "one" => { cache_dir: "/var/cache/one" },
+    "two" => { cache_dir: "/var/cache/two" },
+  }
 end
 ```
 
-In this case you get two buckets called "generic-one" and "generic-two" under guest's
-`/tmp/vagrant-cache`.
+In this case you get two buckets called "one" and "two" under the guest's
+`/tmp/vagrant-cache` directory.
 
 The Generic bucket is useful if you want to implement a caching mechanism by
 hand. For instance, if you want to cache your wget downloads under
@@ -31,7 +33,9 @@ hand. For instance, if you want to cache your wget downloads under
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.cache.enable :generic, { name: "wget", cache_dir: "/var/cache/wget" }
+  config.cache.enable :generic, {
+    "wget" => { cache_dir: "/var/cache/wget" },
+  }
 end
 ```
 

--- a/lib/vagrant-cachier/bucket/generic.rb
+++ b/lib/vagrant-cachier/bucket/generic.rb
@@ -3,12 +3,22 @@ module VagrantPlugins
     class Bucket
       class Generic < Bucket
         def install
+
+          # First we normalize the @configs hash as a hash of hashes
           if @configs.has_key?(:cache_dir)
-            @name = @configs.has_key?(:name) ? "generic-#{@configs[:name]}" : "generic"
-            symlink(@configs[:cache_dir])
-          else
-            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'Generic')
+            @configs = { @name => @configs }
           end
+
+          # Now we iterate through all generic buckets's configurations and
+          # set them up.
+          @configs.each do |key, conf|
+            if conf.has_key?(:cache_dir)
+              symlink(conf[:cache_dir], "/tmp/vagrant-cache/#{key}")
+            else
+              @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: "Generic[#{key}]")
+            end
+          end
+
         end
       end
     end


### PR DESCRIPTION
The previously documented way to specify multiple generic buckets
doesn't work because vagrant-cachier can't enable a bucket type more
than once.

Here we generalize the configs hash that the generic bucket gets making
it possible to specify multiple buckets with a single hash. The
documentation is changed accordingly.

Note that we keep it backwards compatible for single generic bucket
specification.

Issue: https://github.com/fgrehm/vagrant-cachier/issues/99
