### PR TITLE
Add support for caching chef gems (in /opt/chef/embedded).

### DIFF
--- a/docs/buckets/chef_rubygems.md
+++ b/docs/buckets/chef_rubygems.md
@@ -1,0 +1,18 @@
+# Chef RubyGems
+
+When a Chef installation is detected, this bucket caches its embedded gems.
+Most of these gems are part of the Chef omnibus package but sometimes cookbooks
+need to install extra gems to run within the context of a Chef recipe using the
+`chef_gem` resource.
+
+The embedded Chef gem location is returned by running the
+`/opt/chef/embedded/bin/gem env gemdir` command.
+
+To manually enable it:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = 'some-box-using-chef-provisioner'
+  config.cache.enable :chef_gem
+end
+```

--- a/lib/vagrant-cachier/bucket.rb
+++ b/lib/vagrant-cachier/bucket.rb
@@ -90,6 +90,7 @@ end
 require_relative "bucket/apt"
 require_relative "bucket/chef"
 require_relative "bucket/gem"
+require_relative "bucket/chef_gem"
 require_relative "bucket/pacman"
 require_relative "bucket/yum"
 require_relative "bucket/rvm"

--- a/lib/vagrant-cachier/bucket/chef_gem.rb
+++ b/lib/vagrant-cachier/bucket/chef_gem.rb
@@ -1,0 +1,25 @@
+module VagrantPlugins
+  module Cachier
+    class Bucket
+      class ChefGem < Bucket
+        def self.capability
+          :chef_gemdir
+        end
+
+        def install
+          if guest.capability?(:chef_gemdir)
+            if gemdir_path = guest.capability(:chef_gemdir)
+              prefix         = gemdir_path.split('/').last
+              bucket_path    = "/tmp/vagrant-cache/#{@name}/#{prefix}"
+              gem_cache_path = "#{gemdir_path}/cache"
+
+              symlink(gem_cache_path, bucket_path)
+            end
+          else
+            @env[:ui].info I18n.t('vagrant_cachier.skipping_bucket', bucket: 'ChefRubyGems')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cachier/cap/linux/chef_gemdir.rb
+++ b/lib/vagrant-cachier/cap/linux/chef_gemdir.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module Cachier
+    module Cap
+      module Linux
+        module ChefGemdir
+          def self.chef_gemdir(machine)
+            gemdir = nil
+            machine.communicate.tap do |comm|
+              return unless comm.test('test -f /opt/chef/embedded/bin/gem')
+              comm.execute '/opt/chef/embedded/bin/gem env gemdir' do |buffer, output|
+                gemdir = output.chomp if buffer == :stdout
+              end
+            end
+            return gemdir
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-cachier/capabilities.rb
+++ b/lib/vagrant-cachier/capabilities.rb
@@ -6,6 +6,11 @@ module VagrantPlugins
         Cap::Linux::Gemdir
       end
 
+      guest_capability 'linux', 'chef_gemdir' do
+        require_relative 'cap/linux/chef_gemdir'
+        Cap::Linux::ChefGemdir
+      end
+
       guest_capability 'linux', 'rvm_path' do
         require_relative 'cap/linux/rvm_path'
         Cap::Linux::RvmPath


### PR DESCRIPTION
Dear @fgrehm , here is a modest PR to cache gems downloads within Chef's `/opt/chef/embedded` directory.

To give you a bit of context, I live in a country with limited Internet connectivity, which makes running `kitchen converge` quite painful. With this PR I can cache the installation of the `ci-reporter` and `chef-minitest-handler` gems, saving me 10 minutes each time I run either `kitchen test` or the initial `kitchen converge`.