### PR TITLE
Use provisioner type attribute

### DIFF
--- a/lib/vagrant-cachier/cap/linux/chef_file_cache_path.rb
+++ b/lib/vagrant-cachier/cap/linux/chef_file_cache_path.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
           def self.chef_provisioner?(machine)
             provisioners = machine.config.vm.provisioners
             chef_provisioners = [:chef_solo, :chef_client]
-            compat_provisioners = provisioners.keep_if { |p| chef_provisioners.include? p.name }
+            compat_provisioners = provisioners.keep_if { |p| chef_provisioners.include? p.name || p.type }
 
             if compat_provisioners.size > 1
               raise "One machine is using multiple chef provisioners, which is unsupported."


### PR DESCRIPTION
Vagrant changed the provisioner name attribute to type in version 1.7.1.

fixes #133 