### PR TITLE
Do not modify Vagrant core object

### DIFF
--- a/lib/vagrant-cachier/cap/linux/chef_file_cache_path.rb
+++ b/lib/vagrant-cachier/cap/linux/chef_file_cache_path.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
           def self.chef_provisioner?(machine)
             provisioners = machine.config.vm.provisioners
             chef_provisioners = [:chef_solo, :chef_client]
-            compat_provisioners = provisioners.keep_if { |p| chef_provisioners.include? p.name }
+            compat_provisioners = provisioners.select { |p| chef_provisioners.include? p.name }
 
             if compat_provisioners.size > 1
               raise "One machine is using multiple chef provisioners, which is unsupported."


### PR DESCRIPTION
Using [Array#keep_if](http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-keep_if) on a Vagrant core object can lead to unpredictable behaviour down the line as it modifies the object instead of creating a new one.

An example of such interference is described on https://github.com/cassianoleal/vagrant-butcher/issues/57. The problem with `keep_if` was identified by @sethvargo on this issue: https://github.com/mitchellh/vagrant/issues/5060#issuecomment-68107995