### PR TITLE
Allow explicit disabling of auto detected buckets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,22 @@ end
 _Please refer to the "Available Buckets" menu above to find out which buckets
 are supported._
 
+## Disable buckets in auto-detect mode
+
+If for some reason you need to disable certain buckets but want the remaining
+buckets to be configured you can do so by disabling on an individual basis in
+your `Vagrantfile`:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.cache.auto_detect = true
+  config.cache.disable = :chef_gem
+end
+```
+
+_Please refer to the "Available Buckets" menu above to find out which buckets
+are supported._
+
 ## Custom cache buckets synced folders options
 
 For fine grained control over the cache bucket synced folder options you can use

--- a/lib/vagrant-cachier/action/install_buckets.rb
+++ b/lib/vagrant-cachier/action/install_buckets.rb
@@ -39,6 +39,7 @@ module VagrantPlugins
           env[:ui].info 'Configuring cache buckets...'
           cache_config = env[:machine].config.cache
           cache_config.buckets.each do |bucket_name, configs|
+            next if configs[:disabled]
             @logger.info "Installing #{bucket_name} with configs #{configs.inspect}"
             Bucket.install(bucket_name, env, configs)
           end

--- a/lib/vagrant-cachier/bucket.rb
+++ b/lib/vagrant-cachier/bucket.rb
@@ -9,6 +9,10 @@ module VagrantPlugins
       def self.auto_detect(env)
         @buckets.each do |bucket|
           if bucket.respond_to?(:capability) && env[:machine].guest.capability?(bucket.capability)
+            if env[:machine].config.cache.buckets.fetch(bucket.bucket_name, {})[:disabled]
+              env[:machine].ui.warn("Ignoring bucket `#{bucket.bucket_name}` disabled by config")
+              next
+            end
             env[:machine].config.cache.enable bucket.bucket_name
           end
         end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,9 @@ en:
       Skipping %{bucket} cache bucket as the guest machine does not support it
     unknown_cache_scope: |-
       Unknown cache scope '%{cache_scope}' (allowed scopes: %{allowed})
+    disable_requires_auto: |-
+      `config.cache.disable <bucket>` only works if `config.cache.auto_detect`
+      is set to 'true'.
     nfs_required: |-
       The '%{bucket}' cache bucket requires NFS to be enabled, please add
       `config.cache.synced_folder_opts = {type: :nfs}` to your Vagrantfile.

--- a/spec/acceptance/fixtures/auto-detect-disable-apt.rb
+++ b/spec/acceptance/fixtures/auto-detect-disable-apt.rb
@@ -1,0 +1,15 @@
+Vagrant.configure("2") do |config|
+  config.vm.provider :virtualbox do |_, override|
+    override.vm.box = "chef/ubuntu-14.04"
+  end
+
+  config.vm.provider :lxc do |_, override|
+    override.vm.box = "fgrehm/trusty64-lxc"
+  end
+
+  config.cache.auto_detect = true
+  config.cache.disable = :apt
+  config.cache.scope = :machine
+
+  config.vm.provision :shell, inline: 'apt-get update && apt-get install -y git'
+end

--- a/spec/acceptance/sanity_check.bats
+++ b/spec/acceptance/sanity_check.bats
@@ -43,3 +43,19 @@ load test_helper
 
   empty_cache
 }
+
+@test "APT cache bucket disabled skips the cache dir properly" {
+  configure_env "auto-detect-disable-apt.rb"
+
+  test ! -d tmp/.vagrant/machines/default/cache/apt
+
+  vagrant_up
+  [ "$status" -eq 0 ]
+
+  # Make sure cache dir does not exist
+  test ! -d tmp/.vagrant/machines/default/cache/apt
+
+  vagrant_destroy
+
+  empty_cache
+}


### PR DESCRIPTION
Add config option to identify buckets that should not be automatically
enabled with using `config.cache.auto_detect = true`.

After turning on the auto_detect behaviour, with this change you can
now explicitly disable any bucket type through your Vagrantfile e.g.
`config.cache.disable = :chef_gem`.

Fixes #115
