### PR TITLE
Add config.cache.root option to specify a custom cache root.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,20 @@ end
 _Please refer to the "Available Buckets" menu above to find out which buckets
 are supported._
 
+## Custom cache root
+
+You can configure a custom root directory for the cache other than
+`$HOME/.vagrant.d/cache/some-box` in your `Vagrantfile`.
+This is only supported for single machine environments for similar reasons
+as above, and additionally requires that the root directory already exists.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.cache.scope = :box
+  config.cache.root = File.join ENV['XDG_CACHE_HOME'], 'vagrant-cachier'
+end
+```
+
 ## Custom cache buckets synced folders options
 
 For fine grained control over the cache bucket synced folder options you can use

--- a/lib/vagrant-cachier/config.rb
+++ b/lib/vagrant-cachier/config.rb
@@ -1,7 +1,7 @@
 module VagrantPlugins
   module Cachier
     class Config < Vagrant.plugin(2, :config)
-      attr_accessor :scope, :auto_detect, :synced_folder_opts
+      attr_accessor :scope, :auto_detect, :synced_folder_opts, :root
       attr_reader   :buckets
 
       ALLOWED_SCOPES = %w( box machine )
@@ -11,6 +11,7 @@ module VagrantPlugins
         @auto_detect = UNSET_VALUE
         @synced_folder_opts = UNSET_VALUE
         @ui = Vagrant::UI::Colored.new
+        @root = UNSET_VALUE
       end
 
       def enable(bucket, opts = {})
@@ -51,6 +52,7 @@ module VagrantPlugins
         @auto_detect = true if @auto_detect == UNSET_VALUE
         @synced_folder_opts = nil if @synced_folder_opts == UNSET_VALUE
         @buckets = @buckets ? @buckets.dup : {}
+        @root = nil if @root == UNSET_VALUE
       end
 
       private


### PR DESCRIPTION
Only available for single box environments.
Requires that the custom cache root already exists - because it is
custom, it is your responsbility instead of vagrant-cachier's.
Fixes #87.
