### PR TITLE
rename DigitalOcean provider to digital_ocean

### DIFF
--- a/lib/vagrant-cachier/plugin.rb
+++ b/lib/vagrant-cachier/plugin.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
 
     # Keep an eye on https://github.com/mitchellh/vagrant/wiki/Available-Vagrant-Plugins#wiki-providers
     # for more.
-    CLOUD_PROVIDERS = %w( aws cloudstack digitalocean hp joyent openstack rackspace
+    CLOUD_PROVIDERS = %w( aws cloudstack digitalocean digital_ocean hp joyent openstack rackspace
                           softlayer proxmox managed azure brightbox cloudstack vcloud
                           vsphere )
   end


### PR DESCRIPTION
The name of the DigitalOcean plugin gem is `vagrant-digitalocean` but the
actual provider plugin registered with vagrant is `:digital_ocean`.

See: https://github.com/smdahlen/vagrant-digitalocean/blob/9dddc130842beb33e3f5c9796c26bd438bdde953/lib/vagrant-digitalocean/plugin.rb#L10
