### PR TITLE
Announce compatibility with Parallels provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ http://fgrehm.viewdocs.io/vagrant-cachier.
 * [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc)
 * [VMware providers](http://www.vagrantup.com/vmware) with NFS enabled (See
   [GH-24](https://github.com/fgrehm/vagrant-cachier/issues/24) for more info)
+* [vagrant-parallels](https://github.com/Parallels/vagrant-parallels)
 * [vagrant-libvirt](https://github.com/pradels/vagrant-libvirt)
 * [vagrant-kvm](https://github.com/adrahon/vagrant-kvm)
 * _[Let us know if it is compatible with other providers!](https://github.com/fgrehm/vagrant-cachier/issues/new)_


### PR DESCRIPTION
Actually, `vagrant-cachier` is compatible with Parallels provider for a long time already.
So, now it's time to note it in the README.md.

I confirm - it works fine from "out-of-box", e.q. wth native shared folders. And it should also work with NFS  too.

Related to https://github.com/fgrehm/vagrant-cachier/issues/111