### PR TITLE
Allow an override directory for the root of packages to be specified

### DIFF
--- a/lib/vagrant-cachier/action/configure_bucket_root.rb
+++ b/lib/vagrant-cachier/action/configure_bucket_root.rb
@@ -21,12 +21,13 @@ module VagrantPlugins
         end
 
         def setup_buckets_folder
-          FileUtils.mkdir_p(cache_root.to_s) unless cache_root.exist?
+#         FileUtils.mkdir_p(cache_root.to_s) unless cache_root.exist?
 
           synced_folder_opts = {id: "vagrant-cache"}
           synced_folder_opts.merge!(@env[:machine].config.cache.synced_folder_opts || {})
+          puts(@env[:machine].config.cache.override_directory)
 
-          @env[:machine].config.vm.synced_folder cache_root, '/tmp/vagrant-cache', synced_folder_opts
+          @env[:machine].config.vm.synced_folder @env[:machine].config.cache.override_directory || cache_root, '/tmp/vagrant-cache', synced_folder_opts
           @env[:cache_dirs] = []
         end
 

--- a/lib/vagrant-cachier/action/configure_bucket_root.rb
+++ b/lib/vagrant-cachier/action/configure_bucket_root.rb
@@ -48,16 +48,16 @@ module VagrantPlugins
                 bucket_name = @box_name
               end
               # An override directory has been specified. Use this as the base instead of the standard directory
-              if !@env[:machine].config.cache.override_directory.nil?
-                  base_path = Pathname.new(@env[:machine].config.cache.override_directory)
+              if !@env[:machine].config.cache.override_base_directory.nil?
+                  base_path = Pathname.new(@env[:machine].config.cache.override_base_directory)
               else
                   base_path = @env[:home_path]
               end
               base_path.join('cache', bucket_name)
             when :machine
               # An override directory has been specified. Use this as the base instead of the standard directory
-              if !@env[:machine].config.cache.override_directory.nil?
-                  base_path = Pathname.new(@env[:machine].config.cache.override_directory)
+              if !@env[:machine].config.cache.override_base_directory.nil?
+                  base_path = Pathname.new(@env[:machine].config.cache.override_base_directory)
                   base_path += @env[:machine].name.to_s
               else
                   base_path = @env[:machine].data_dir.parent

--- a/lib/vagrant-cachier/action/configure_bucket_root.rb
+++ b/lib/vagrant-cachier/action/configure_bucket_root.rb
@@ -21,13 +21,14 @@ module VagrantPlugins
         end
 
         def setup_buckets_folder
-#         FileUtils.mkdir_p(cache_root.to_s) unless cache_root.exist?
 
           synced_folder_opts = {id: "vagrant-cache"}
           synced_folder_opts.merge!(@env[:machine].config.cache.synced_folder_opts || {})
-          puts(@env[:machine].config.cache.override_directory)
+          puts([@env[:machine].config.cache.override_directory, cache_root].join(''))
 
-          @env[:machine].config.vm.synced_folder @env[:machine].config.cache.override_directory || cache_root, '/tmp/vagrant-cache', synced_folder_opts
+          FileUtils.mkdir_p([@env[:machine].config.cache.override_directory, cache_root].join('').to_s) unless File.directory?([@env[:machine].config.cache.override_directory, cache_root].join('').to_s)
+
+          @env[:machine].config.vm.synced_folder [@env[:machine].config.cache.override_directory, cache_root].join(''), '/tmp/vagrant-cache', synced_folder_opts
           @env[:cache_dirs] = []
         end
 

--- a/lib/vagrant-cachier/config.rb
+++ b/lib/vagrant-cachier/config.rb
@@ -1,7 +1,7 @@
 module VagrantPlugins
   module Cachier
     class Config < Vagrant.plugin(2, :config)
-      attr_accessor :scope, :auto_detect, :synced_folder_opts, :override_directory
+      attr_accessor :scope, :auto_detect, :synced_folder_opts, :override_base_directory
       attr_reader   :buckets
 
       ALLOWED_SCOPES = %w( box machine )

--- a/lib/vagrant-cachier/config.rb
+++ b/lib/vagrant-cachier/config.rb
@@ -1,7 +1,7 @@
 module VagrantPlugins
   module Cachier
     class Config < Vagrant.plugin(2, :config)
-      attr_accessor :scope, :auto_detect, :synced_folder_opts
+      attr_accessor :scope, :auto_detect, :synced_folder_opts, :override_directory
       attr_reader   :buckets
 
       ALLOWED_SCOPES = %w( box machine )


### PR DESCRIPTION
The goal of this request is to allow the root directory that is used for cache to be specified by the user. It may be considered an edge case as NFS cannot mount encrypted directories (such as an encrypted home directory)

More details in #183 

Thanks. Please let me know if there are any issues.